### PR TITLE
feat: resolving issue #8 #9 and #10

### DIFF
--- a/backend/.tes_instances
+++ b/backend/.tes_instances
@@ -3,14 +3,13 @@
 # Lines starting with # are comments
 
 # ELIXIR Cloud TES Instances
-Funnel/OpenPBS @ ELIXIR-CZ,https://funnel.cloud.e-infra.cz/
-Funnel/Slurm @ ELIXIR-FI,https://vm4816.kaj.pouta.csc.fi/
-TESK/Kubernetes @ ELIXIR-CZ (Prod),https://tesk-prod.cloud.e-infra.cz/
-TESK/Kubernetes @ ELIXIR-CZ (NA),https://tesk-na.cloud.e-infra.cz/
-TESK/Kubernetes @ ELIXIR-DE,https://tesk.elixir-cloud.bi.denbi.de/
-TESK/Kubernetes @ ELIXIR-GR,https://tesk-eu.hypatia-comp.athenarc.gr/
-TESK/OpenShift @ ELIXIR-FI,https://csc-tesk-noauth.rahtiapp.fi/
-TESK North America,https://tesk-na.cloud.e-infra.cz/
+Funnel/OpenPBS @ ELIXIR-CZ (Not Working),https://funnel.cloud.e-infra.cz/
+Funnel/Slurm @ ELIXIR-FI (DNS resolution Failure),https://vm4816.kaj.pouta.csc.fi/
+TESK/Kubernetes @ ELIXIR-CZ (Prod) (Auth Failure),https://tesk-prod.cloud.e-infra.cz/
+TESK/Kubernetes @ ELIXIR-CZ (NA) (403 Forbidden),https://tesk-na.cloud.e-infra.cz/
+TESK/Kubernetes @ ELIXIR-DE (DNS resolution Failure),https://tesk.elixir-cloud.bi.denbi.de/
+TESK/Kubernetes @ ELIXIR-GR (Working),https://tesk-eu.hypatia-comp.athenarc.gr/
+TESK/OpenShift @ ELIXIR-FI (Working),https://csc-tesk-noauth.rahtiapp.fi/
 
 # Local Development
 Local TES,http://localhost:8080

--- a/backend/.tes_instances
+++ b/backend/.tes_instances
@@ -3,13 +3,13 @@
 # Lines starting with # are comments
 
 # ELIXIR Cloud TES Instances
-Funnel/OpenPBS @ ELIXIR-CZ (Not Working),https://funnel.cloud.e-infra.cz/
-Funnel/Slurm @ ELIXIR-FI (DNS resolution Failure),https://vm4816.kaj.pouta.csc.fi/
-TESK/Kubernetes @ ELIXIR-CZ (Prod) (Auth Failure),https://tesk-prod.cloud.e-infra.cz/
-TESK/Kubernetes @ ELIXIR-CZ (NA) (403 Forbidden),https://tesk-na.cloud.e-infra.cz/
-TESK/Kubernetes @ ELIXIR-DE (DNS resolution Failure),https://tesk.elixir-cloud.bi.denbi.de/
-TESK/Kubernetes @ ELIXIR-GR (Working),https://tesk-eu.hypatia-comp.athenarc.gr/
-TESK/OpenShift @ ELIXIR-FI (Working),https://csc-tesk-noauth.rahtiapp.fi/
+Funnel/OpenPBS @ ELIXIR-CZ,https://funnel.cloud.e-infra.cz/
+Funnel/Slurm @ ELIXIR-FI,https://vm4816.kaj.pouta.csc.fi/
+TESK/Kubernetes @ ELIXIR-CZ (Prod),https://tesk-prod.cloud.e-infra.cz/
+TESK/Kubernetes @ ELIXIR-CZ (NA),https://tesk-na.cloud.e-infra.cz/
+TESK/Kubernetes @ ELIXIR-DE,https://tesk.elixir-cloud.bi.denbi.de/
+TESK/Kubernetes @ ELIXIR-GR,https://tesk-eu.hypatia-comp.athenarc.gr/
+TESK/OpenShift @ ELIXIR-FI,https://csc-tesk-noauth.rahtiapp.fi/
 
 # Local Development
 Local TES,http://localhost:8080

--- a/backend/routes/instances.py
+++ b/backend/routes/instances.py
@@ -28,6 +28,27 @@ def get_healthy_instances_route():
         print(f"❌ Error in get_healthy_instances: {str(e)}")
         return jsonify({'error': str(e)}), 500
 
+@instances_bp.route('/api/instances-with-status', methods=['GET'])
+def get_instances_with_status():
+    """Get all TES instances with their current health status"""
+    try:
+        from utils.tes_utils import load_tes_location_data
+        instances = load_tes_location_data()
+        
+        # Fetch status for all instances in parallel
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(fetch_tes_status, instances))
+        
+        return jsonify({
+            'instances': results,
+            'count': len(results),
+            'last_updated': datetime.now(timezone.utc).isoformat()
+        })
+        
+    except Exception as e:
+        print(f"Error in get_instances_with_status: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+
 @instances_bp.route('/api/tes_locations', methods=['GET'])
 def tes_locations():
     from utils.tes_utils import load_tes_location_data

--- a/frontend/src/hooks/useInstances.js
+++ b/frontend/src/hooks/useInstances.js
@@ -4,6 +4,7 @@ import instanceService from '../services/instanceService';
 const useInstances = () => {
   const [state, setState] = useState({
     instances: [],
+    allInstances: [],
     loading: true,
     error: null,
     lastUpdate: null
@@ -15,7 +16,11 @@ const useInstances = () => {
     };
     instanceService.addListener(handleUpdate);
     const initialState = instanceService.getHealthyInstances();
-    setState(initialState);
+    const allInstancesState = instanceService.getAllInstancesWithStatus();
+    setState({
+      ...initialState,
+      allInstances: allInstancesState.instances
+    });
     return () => {
       instanceService.removeListener(handleUpdate);
     };
@@ -26,6 +31,7 @@ const useInstances = () => {
 
   return {
     instances: state.instances,
+    allInstances: state.allInstances,
     loading: state.loading,
     error: state.error,
     lastUpdate: state.lastUpdate,

--- a/frontend/src/pages/SubmitTask.js
+++ b/frontend/src/pages/SubmitTask.js
@@ -220,7 +220,8 @@ const SubmitTask = () => {
         setFormData(prev => ({ ...prev, tes_instance: healthyInstance.url }));
       }
     }
-  }, [instances, allInstances, formData.tes_instance]);
+
+  }, [instances, allInstances]);
 
   const handleTestConnection = async () => {
     try {
@@ -274,38 +275,38 @@ const SubmitTask = () => {
       basic: {
         tes_instance: defaultTesInstance,
         task_name: 'Demo Hello World Task',
-        docker_image: 'ubuntu:20.04',
-        command: 'echo "Hello from TES Demo Task!" && echo "Current time: $(date)" && echo "System info: $(uname -a)" && echo "Task completed successfully"',
+        docker_image: 'alpine:latest',
+        command: 'echo "Hello from TES!" && date && uname -a',
         input_url: '',
         output_url: '',
         cpu_cores: '1',
         ram_gb: '1',
-        disk_gb: '5',
-        description: 'A simple demo task that prints system information and a hello message. Safe to run and completes quickly for testing purposes.'
+        disk_gb: '1',
+        description: 'Simple demo task using Alpine Linux (5MB). Note: If you see SYSTEM_ERROR, the TES instance may be experiencing infrastructure issues. Try a different instance or wait a few minutes.'
       },
       python: {
         tes_instance: defaultTesInstance,
         task_name: 'Demo Python Script Task',
-        docker_image: 'python:3.9-slim',
-        command: 'python3 -c "import sys; import datetime; print(f\'Hello from Python {sys.version}\'); print(f\'Current time: {datetime.datetime.now()}\'); print(\'Demo task completed successfully!\')"',
+        docker_image: 'python:3.11-alpine',
+        command: 'python3 -c "import sys; import datetime; print(sys.version); print(datetime.datetime.now())"',
         input_url: '',
         output_url: '',
         cpu_cores: '1',
         ram_gb: '1',
-        disk_gb: '5',
-        description: 'A Python demo task that prints version info and timestamp using a Python container.'
+        disk_gb: '1',
+        description: 'Python demo using Alpine-based image (51MB). Faster than standard Python images.'
       },
       fileops: {
         tes_instance: defaultTesInstance,
         task_name: 'Demo File Operations Task',
-        docker_image: 'ubuntu:20.04',
-        command: 'echo "Creating demo files..." && echo "Hello World" > /tmp/output.txt && echo "File contents:" && cat /tmp/output.txt && ls -la /tmp/',
+        docker_image: 'alpine:latest',
+        command: 'echo "Hello World" > /tmp/demo.txt && cat /tmp/demo.txt && ls -lh /tmp/demo.txt',
         input_url: '',
         output_url: '',
         cpu_cores: '1',
         ram_gb: '1',
-        disk_gb: '5',
-        description: 'A demo task that creates and reads files, demonstrating basic file operations within the container.'
+        disk_gb: '1',
+        description: 'Demonstrates file creation and reading in Alpine Linux.'
       }
     };
     
@@ -458,14 +459,15 @@ const SubmitTask = () => {
               {(allInstances.length > 0 ? allInstances : instances)
                 .slice()
                 .sort((a, b) => {
-                  // Sort by status: healthy first, then others
+                  // Sort by status: healthy (reachable without auth) first, then others
+                  // Note: Backend marks instances requiring auth as 'unhealthy'
                   if (a.status === 'healthy' && b.status !== 'healthy') return -1;
                   if (a.status !== 'healthy' && b.status === 'healthy') return 1;
                   return 0;
                 })
-                .map((instance, index) => (
+                .map((instance) => (
                   <option 
-                    key={index} 
+                    key={instance.url} 
                     value={instance.url}
                   >
                     {getStatusBadge(instance.status)} {instance.name}

--- a/frontend/src/pages/SubmitTask.js
+++ b/frontend/src/pages/SubmitTask.js
@@ -8,6 +8,8 @@ import ErrorMessage from '../components/common/ErrorMessage';
 import useInstances from '../hooks/useInstances';
 import { ArrowLeft, Play, Zap, RefreshCw } from 'lucide-react';
 
+const ELIXIR_FI_INSTANCE_SUBSTRING = 'csc-tesk-noauth.rahtiapp.fi';
+
 const PageContainer = styled.div`
   padding: 20px;
   background-color: #f8f9fa;
@@ -201,12 +203,10 @@ const SubmitTask = () => {
     refresh: refreshInstances 
   } = useInstances();
 
-  // Issue #8: bug: set TES Instance for Demo task to healthy instance 
-
   useEffect(() => {
     if (instances.length > 0 && !formData.tes_instance) {
       const elixirFiInstance = instances.find(
-        instance => instance.url && instance.url.includes('csc-tesk-noauth.rahtiapp.fi')
+        instance => instance.url && instance.url.includes(ELIXIR_FI_INSTANCE_SUBSTRING)
       );
       
       if (elixirFiInstance) {
@@ -215,7 +215,7 @@ const SubmitTask = () => {
         setFormData(prev => ({ ...prev, tes_instance: instances[0].url }));
       }
     }
-  }, [instances]);
+  }, [instances, formData.tes_instance]);
 
   const handleTestConnection = async () => {
     try {
@@ -304,15 +304,6 @@ const SubmitTask = () => {
     const demoData = getDemoTaskData(demoType);
     setFormData(demoData);
     setError(null);
-
-    // Issue #9: remove demo task pop-ups upon form population
-    // const taskNames = {
-    //   basic: 'Basic Hello World',
-    //   python: 'Python Script',
-    //   fileops: 'File Operations'
-    // };
-    
-    // alert(`${taskNames[demoType] || 'Demo'} task data loaded! Review the form and click "Submit Task" when ready.`);
   };
 
   const handleSubmit = async (e) => {
@@ -346,12 +337,7 @@ const SubmitTask = () => {
       const result = await taskService.submitTask(submitData);
       
       console.log('Task submission result:', result);
-       
-      // if (result && result.message) {
-      //   alert(`Success: ${result.message}`);
-      // } else {
-      //   alert('Task submitted successfully!');
-      // }
+      
       navigate('/tasks');
     } catch (err) {
       console.error('Task submission error:', err);
@@ -457,11 +443,10 @@ const SubmitTask = () => {
               required
             >
               <option value="">Select TES Instance</option>
-              {instances
+              {[...instances]
                 .sort((a, b) => {
-                  // Prioritize ELIXIR-Fi instance at the top
-                  const aIsElixirFi = a.url && a.url.includes('csc-tesk-noauth.rahtiapp.fi');
-                  const bIsElixirFi = b.url && b.url.includes('csc-tesk-noauth.rahtiapp.fi');
+                  const aIsElixirFi = a.url && a.url.includes(ELIXIR_FI_INSTANCE_SUBSTRING);
+                  const bIsElixirFi = b.url && b.url.includes(ELIXIR_FI_INSTANCE_SUBSTRING);
                   if (aIsElixirFi && !bIsElixirFi) return -1;
                   if (!aIsElixirFi && bIsElixirFi) return 1;
                   return 0;

--- a/frontend/src/pages/Utilities.js
+++ b/frontend/src/pages/Utilities.js
@@ -406,7 +406,7 @@ const Utilities = () => {
       ));
        
       const serviceInfo = response.data;
-      let successMessage = `✅ Connection Test Successful!\n\nInstance: ${instanceName}\nResponse Time: ${responseTime}ms`;
+      let successMessage = `Connection Test Successful!\n\nInstance: ${instanceName}\nResponse Time: ${responseTime}ms`;
       
       if (serviceInfo && serviceInfo.name) {
         successMessage += `\nService Name: ${serviceInfo.name}`;
@@ -417,7 +417,7 @@ const Utilities = () => {
       
       alert(successMessage);
     } catch (error) { 
-      let errorMessage = `❌ Connection Test Failed\n\nInstance: ${instanceName}\nURL: ${url}\n\n`;
+      let errorMessage = `Connection Test Failed\n\nInstance: ${instanceName}\nURL: ${url}\n\n`;
       let errorReason = '';
       let errorCode = '';
       let errorType = '';


### PR DESCRIPTION
- Issue #8 (SOLVED)
   Solution - now the Finland instance is set as a default and i have created get_instances_with_status() function which helps in providing all TES instances with their current health status which is to be shown in the dropdown

- issue #9 (SOLVED)
   Solution - I have removed the Alert now the details will directly display in the form without any alert functionality

- issue #10 (SOLVED)
   Solution - same as for issue #9, i have removed alert.

Implementation Screenshot: 
<img width="870" height="397" alt="Screenshot 2026-01-25 at 2 22 43 PM" src="https://github.com/user-attachments/assets/b4b31c34-02a9-4b99-8324-36607bf825ae" />

## Summary by Sourcery

Set a healthy TES instance as the default for demo task submissions and streamline the demo and submission UX by removing alert pop-ups and clarifying connection test messaging.

New Features:
- Automatically select the ELIXIR-FI TES instance by default for demo task submissions when available, falling back to the first available instance.

Bug Fixes:
- Ensure demo task forms are populated without disruptive alert pop-ups, and navigate directly to the tasks view after submission without success alerts.

Enhancements:
- Prioritize the ELIXIR-FI TES instance at the top of the TES instance dropdown to highlight the recommended endpoint.
- Simplify connection test success and failure messages by removing emoji-style prefixes while retaining diagnostic details.