### PR TITLE
feat: issue #11 and issue#12

### DIFF
--- a/backend/services/task_service.py
+++ b/backend/services/task_service.py
@@ -86,7 +86,7 @@ def update_single_task_status(task):
     return False
 
 def update_task_statuses():
-    terminal_states = ['COMPLETE', 'CANCELED', 'SYSTEM_ERROR', 'EXECUTOR_ERROR', 'PREEMPTED']
+    terminal_states = ['COMPLETE', 'CANCELED', 'SYSTEM_ERROR', 'EXECUTOR_ERROR', 'PREEMPTED', 'SUBMISSION_FAILED']
     
     while True:
         try:

--- a/frontend/src/pages/Tasks.js
+++ b/frontend/src/pages/Tasks.js
@@ -231,11 +231,7 @@ const Tasks = () => {
       return task && 
              task.id && 
              task.tes_url && 
-             task.state &&
-             task.state !== 'ERROR' &&
-             task.state !== 'SYSTEM_ERROR' &&
-             task.state !== 'EXECUTOR_ERROR' && 
-             !task.error_prone_instance;
+             task.state;
     });
 
     if (!searchTerm) {


### PR DESCRIPTION
###  Issue #11  (SOLVED)
   - Solution -Added SUBMISSION_FAILED state for tasks that fail to submit
Logged failed submissions to the task list with:
Error message
Error type (DNS, timeout, auth, etc.)
Error code
Error reason
TES instance details
Timestamp
Captured both failure scenarios:
-> Connectivity failures (can't reach the instance)
-> HTTP errors (instance reachable but rejects task: 400, 403, 500, etc.)

###  issue #12 (SOLVED)
   Solution - 
1. Backend Fix task_service.py
Added 'SUBMISSION_FAILED' to the terminal_states list (line 89). This prevents the background task updater from trying to fetch status updates for failed submissions from the TES instance.

**Why this matters:** Tasks with SUBMISSION_FAILED state were never actually submitted to the TES instance, so when the background updater tried to fetch their status, it would fail or corrupt the task data, causing them to disappear from the list.

2. Frontend Fix Tasks.js
Removed the filter that was excluding error states (ERROR, SYSTEM_ERROR, EXECUTOR_ERROR) and the error_prone_instance check (lines 230-238). Now the filter only checks for essential fields (id, tes_url, state).

### Implementation Screenshot: 
<img width="1207" height="502" alt="Screenshot 2026-01-25 at 7 32 34 PM" src="https://github.com/user-attachments/assets/a7ca7250-fc07-459d-9146-149469c415f2" />
<img width="1193" height="785" alt="Screenshot 2026-01-25 at 7 33 18 PM" src="https://github.com/user-attachments/assets/c1152868-e4cb-4a5b-93d2-5d34717a7c4b" />

## Summary by Sourcery

Handle failed TES task submissions as first-class tasks and ensure error states remain visible in the task list.

New Features:
- Record failed TES task submissions as SUBMISSION_FAILED tasks with detailed error metadata for connectivity and HTTP failures.

Bug Fixes:
- Normalize task command handling to correctly support both string and list commands and avoid demo tasks getting stuck.
- Include SUBMISSION_FAILED in terminal task states to prevent background status polling of never-submitted tasks.
- Show tasks in all error states on the Tasks page by removing filters that hid error and error-prone instances.